### PR TITLE
remove enableServiceLinks when false

### DIFF
--- a/charts/keycloak/templates/statefulset.yaml
+++ b/charts/keycloak/templates/statefulset.yaml
@@ -151,7 +151,9 @@ spec:
       hostAliases:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.enableServiceLinks }}
       enableServiceLinks: {{ .Values.enableServiceLinks }}
+      {{- end }}
       restartPolicy: {{ .Values.restartPolicy }}
       {{- with .Values.nodeSelector }}
       nodeSelector:


### PR DESCRIPTION
The specification of `enableServiceLinks` gives an error on older Kubernetes versions.
`enableServiceLinks` is now only specified when its value is 

Signed-off-by: Brent Van Laere <brent.van.laere@gmail.com>